### PR TITLE
Avoid permanent scrollbars

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -10,7 +10,7 @@
   height: 100%;
   width: 100%;
   color: $white;
-  overflow: scroll;
+  overflow: auto;
 
   &__content {
     display: flex;


### PR DESCRIPTION
Removed `overflow: scroll` to avoid permanent scrollbars that were visible even if there were no overflows.

It was quite annoying, so I decided to fix it - I hope you don't mind :stuck_out_tongue: 